### PR TITLE
 Fix various issues with lc_mini_math

### DIFF
--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -2458,7 +2458,7 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T> tmat4x4<T> perspectiveLH(T fovy, T aspect, T zNear, T zFar) {
-        assert(abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
+        assert(std::abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
 
         T const tanHalfFovy = tan(fovy / static_cast<T>(2));
 
@@ -2479,7 +2479,7 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T> tmat4x4<T> perspectiveRH(T fovy, T aspect, T zNear, T zFar) {
-        assert(abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
+        assert(std::abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
 
         T const tanHalfFovy = tan(fovy / static_cast<T>(2));
 

--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -40,6 +40,8 @@ Large portions of lc_mini_math is borrowed from GLM:
 #endif 
 
 #include <cmath>
+#include <cstddef>
+#include <limits>
 
 #define LC_DEPTH_ZERO_TO_ONE            0x00000001
 #define LC_DEPTH_NEGATIVE_ONE_TO_ONE    0x00000002
@@ -48,7 +50,7 @@ Large portions of lc_mini_math is borrowed from GLM:
     #define LC_DEPTH_CLIP_SPACE         LC_DEPTH_ZERO_TO_ONE
 #endif
 
-#if ! defined( MINIMATH_NAMESPACE )
+#if ! defined( LC_MINIMATH_NAMESPACE )
     #define LC_MINIMATH_NAMESPACE lc
 #endif 
 
@@ -109,8 +111,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename U>
         tvec2<T>&   operator=(const tvec4<U>& v);
 
-        T&          operator[](size_t i);
-        const T&    operator[](size_t i) const;
+        T&          operator[](std::size_t i);
+        const T&    operator[](std::size_t i) const;
 
         tvec2<T>&   operator+=(const tvec2<T>& v);
         tvec2<T>&   operator-=(const tvec2<T>& v);
@@ -183,8 +185,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename U>
         tvec3<T>&   operator=(const tvec4<U>& m);
 
-        T&          operator[](size_t i);
-        const T&    operator[](size_t i) const;
+        T&          operator[](std::size_t i);
+        const T&    operator[](std::size_t i) const;
 
         tvec3<T>&   operator+=(const tvec3<T>& m);
         tvec3<T>&   operator-=(const tvec3<T>& m);
@@ -285,8 +287,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename U>
         tvec4<T>&   operator=(const tvec4<U>& v);
 
-        T&          operator[](size_t i);
-        const T&    operator[](size_t i) const;
+        T&          operator[](std::size_t i);
+        const T&    operator[](std::size_t i) const;
 
         tvec4<T>&   operator+=(const tvec4<T>& v);
         tvec4<T>&   operator-=(const tvec4<T>& v);
@@ -337,8 +339,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename U>
         tmat2x2<T>& operator=(const tmat2x2<U>& m);
 
-        col_type&           operator[](size_t i);
-        const col_type&     operator[](size_t i) const;
+        col_type&           operator[](std::size_t i);
+        const col_type&     operator[](std::size_t i) const;
 
         tmat2x2<T>& operator+=(const tmat2x2<T>& v);
         tmat2x2<T>& operator-=(const tmat2x2<T>& v);
@@ -350,8 +352,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename S>   tmat2x2<T>&   operator*=(const S& s);
         template <typename S>   tmat2x2<T>&   operator/=(const S& s);
 
-        tmat2x2<T> _inverse(); 
-        tmat2x2<T> _tranpose();
+        tmat2x2<T> _inverse() const;
+        tmat2x2<T> _transpose() const;
     };
 
     //! \struct tmat3x3
@@ -396,8 +398,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename U>
         tmat3x3<T>& operator=(const tmat3x3<U>& m);
 
-        col_type&           operator[](size_t i);
-        const col_type&     operator[](size_t i) const;
+        col_type&           operator[](std::size_t i);
+        const col_type&     operator[](std::size_t i) const;
 
         tmat3x3<T>& operator+=(const tmat3x3<T>& m);
         tmat3x3<T>& operator-=(const tmat3x3<T>& m);
@@ -409,8 +411,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename S>   tmat3x3<T>&   operator*=(const S& s);
         template <typename S>   tmat3x3<T>&   operator/=(const S& s);
 
-        tmat3x3<T> _inverse(); 
-        tmat3x3<T> _tranpose();
+        tmat3x3<T> _inverse() const;
+        tmat3x3<T> _transpose() const;
     };
 
     //! \struct tmat4x4
@@ -458,8 +460,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename U>
         tmat4x4<T>& operator=(const tmat4x4<U>& m);
 
-        col_type&           operator[](size_t i);
-        const col_type&     operator[](size_t i) const;
+        col_type&           operator[](std::size_t i);
+        const col_type&     operator[](std::size_t i) const;
 
         tmat4x4<T>& operator+=(const tmat4x4<T>& m);
         tmat4x4<T>& operator-=(const tmat4x4<T>& m);
@@ -471,8 +473,8 @@ namespace LC_MINIMATH_NAMESPACE {
         template <typename S>   tmat4x4<T>&   operator*=(const S& s);
         template <typename S>   tmat4x4<T>&   operator/=(const S& s);
 
-        tmat4x4<T> _inverse(); 
-        tmat4x4<T> _tranpose();
+        tmat4x4<T> _inverse() const;
+        tmat4x4<T> _transpose() const;
     };
 
     template <typename T> struct tquat {
@@ -515,6 +517,26 @@ namespace LC_MINIMATH_NAMESPACE {
     };
     */
 
+    // Operator: v*v
+    template <typename T> tvec2<T> operator*(const tvec2<T>& v1, const tvec2<T>& v2);
+    template <typename T> tvec3<T> operator*(const tvec3<T>& v1, const tvec3<T>& v2);
+    template <typename T> tvec4<T> operator*(const tvec4<T>& v1, const tvec4<T>& v2);
+
+    // Operator: v/v
+    template <typename T> tvec2<T> operator/(const tvec2<T>& v1, const tvec2<T>& v2);
+    template <typename T> tvec3<T> operator/(const tvec3<T>& v1, const tvec3<T>& v2);
+    template <typename T> tvec4<T> operator/(const tvec4<T>& v1, const tvec4<T>& v2);
+
+    // Operator: v+v
+    template <typename T> tvec2<T> operator+(const tvec2<T>& v1, const tvec2<T>& v2);
+    template <typename T> tvec3<T> operator+(const tvec3<T>& v1, const tvec3<T>& v2);
+    template <typename T> tvec4<T> operator+(const tvec4<T>& v1, const tvec4<T>& v2);
+
+    // Operator: v-v
+    template <typename T> tvec2<T> operator-(const tvec2<T>& v1, const tvec2<T>& v2);
+    template <typename T> tvec3<T> operator-(const tvec3<T>& v1, const tvec3<T>& v2);
+    template <typename T> tvec4<T> operator-(const tvec4<T>& v1, const tvec4<T>& v2);
+
     // Operator: v*s, s*v
     template <typename T, typename S> tvec2<T> operator*(const tvec2<T>& v, const S& s);
     template <typename T, typename S> tvec2<T> operator*(const S& s, const tvec2<T>& v);
@@ -538,6 +560,11 @@ namespace LC_MINIMATH_NAMESPACE {
     template <typename T> tmat3x3<T> operator*(const tvec3<T>& v, const tmat3x3<T>& m);
     template <typename T> tmat4x4<T> operator*(const tmat4x4<T>& m, const tvec4<T>& v);
     template <typename T> tmat4x4<T> operator*(const tvec4<T>& v, const tmat4x4<T>& m);
+
+    // Operator: m*m
+    template <typename T> tmat2x2<T> operator*(const tmat2x2<T>& m1, const tmat2x2<T>& m2);
+    template <typename T> tmat3x3<T> operator*(const tmat3x3<T>& m1, const tmat3x3<T>& m2);
+    template <typename T> tmat4x4<T> operator*(const tmat4x4<T>& m1, const tmat4x4<T>& m2);
 
     // Dot
     template <typename T> T dot(const tvec2<T>& v1, const tvec2<T>& v2);
@@ -680,13 +707,13 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    T& tvec2<T>::operator[](size_t i) {
-        return &x[i];
+    T& tvec2<T>::operator[](std::size_t i) {
+        return (&x)[i];
     }
 
     template <typename T>
-    const T& tvec2<T>::operator[](size_t i) const {
-        return &x[i];
+    const T& tvec2<T>::operator[](std::size_t i) const {
+        return (&x)[i];
     }
 
     template <typename T>
@@ -869,13 +896,13 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    T& tvec3<T>::operator[](size_t i) {
-        return &x[i];
+    T& tvec3<T>::operator[](std::size_t i) {
+        return (&x)[i];
     }
 
     template <typename T>
-    const T& tvec3<T>::operator[](size_t i) const {
-        return &x[i];
+    const T& tvec3<T>::operator[](std::size_t i) const {
+        return (&x)[i];
     }
 
     template <typename T>
@@ -1137,13 +1164,13 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    T& tvec4<T>::operator[](size_t i) {
-        return &x[i];
+    T& tvec4<T>::operator[](std::size_t i) {
+        return (&x)[i];
     }
 
     template <typename T>
-    const T& tvec4<T>::operator[](size_t i) const {
-        return &x[i];
+    const T& tvec4<T>::operator[](std::size_t i) const {
+        return (&x)[i];
     }
 
     template <typename T>
@@ -1297,12 +1324,12 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    typename tmat2x2<T>::col_type& tmat2x2<T>::operator[](size_t i) {
+    typename tmat2x2<T>::col_type& tmat2x2<T>::operator[](std::size_t i) {
         return this->value[i];
     }
 
     template <typename T>
-    const typename tmat2x2<T>::col_type& tmat2x2<T>::operator[](size_t i) const {
+    const typename tmat2x2<T>::col_type& tmat2x2<T>::operator[](std::size_t i) const {
         return this->value[i];
     }
 
@@ -1367,8 +1394,8 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    tmat2x2<T> tmat2x2<T>::_inverse() {
-        auto& m = this->value;
+    tmat2x2<T> tmat2x2<T>::_inverse() const {
+        const auto& m = this->value;
 
 		T OneOverDeterminant = static_cast<T>(1) / (
 			+ m[0][0] * m[1][1]
@@ -1384,9 +1411,9 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    tmat2x2<T> tmat2x2<T>::_tranpose() {
+    tmat2x2<T> tmat2x2<T>::_transpose() const {
 		tmat2x2 Transpose(detail::uninitialize);
-        auto& m = this->value;
+        const auto& m = this->value;
 
 		Transpose[0][0] = m[0][0];
 		Transpose[0][1] = m[1][0];
@@ -1483,12 +1510,12 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    typename tmat3x3<T>::col_type& tmat3x3<T>::operator[](size_t i) {
+    typename tmat3x3<T>::col_type& tmat3x3<T>::operator[](std::size_t i) {
         return this->value[i];
     }
 
     template <typename T>
-    const typename tmat3x3<T>::col_type& tmat3x3<T>::operator[](size_t i) const {
+    const typename tmat3x3<T>::col_type& tmat3x3<T>::operator[](std::size_t i) const {
         return this->value[i];
     }
 
@@ -1561,7 +1588,7 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    tmat3x3<T> tmat3x3<T>::_inverse() {
+    tmat3x3<T> tmat3x3<T>::_inverse() const {
         auto& m = this->value;
 
 		T OneOverDeterminant = static_cast<T>(1) / (
@@ -1584,9 +1611,9 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    tmat3x3<T> tmat3x3<T>::_tranpose() {
+    tmat3x3<T> tmat3x3<T>::_transpose() const {
 		tmat3x3 Transpose(detail::uninitialize);
-        auto& m = this->value;
+        const auto& m = this->value;
 
 		Transpose[0][0] = m[0][0];
 		Transpose[0][1] = m[1][0];
@@ -1701,12 +1728,12 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    typename tmat4x4<T>::col_type& tmat4x4<T>::operator[](size_t i) {
+    typename tmat4x4<T>::col_type& tmat4x4<T>::operator[](std::size_t i) {
         return this->value[i];
     }
 
     template <typename T>
-    const typename tmat4x4<T>::col_type& tmat4x4<T>::operator[](size_t i) const {
+    const typename tmat4x4<T>::col_type& tmat4x4<T>::operator[](std::size_t i) const {
         return this->value[i];
     }
 
@@ -1730,10 +1757,14 @@ namespace LC_MINIMATH_NAMESPACE {
 
     template <typename T>
     tmat4x4<T>& tmat4x4<T>::operator*=(const tmat4x4<T>& m) {
-        this->value[0] *= m.value[0];
-        this->value[1] *= m.value[1];
-        this->value[2] *= m.value[2];
-        this->value[3] *= m.value[3];
+      const auto v0 = this->value[0];
+      const auto v1 = this->value[1];
+      const auto v2 = this->value[2];
+      const auto v3 = this->value[3];
+      this->value[0] = v0 * m.value[0][0] + v1 * m.value[0][1] + v2 * m.value[0][2] + v3 * m.value[0][3];
+      this->value[1] = v0 * m.value[1][0] + v1 * m.value[1][1] + v2 * m.value[1][2] + v3 * m.value[1][3];
+      this->value[2] = v0 * m.value[2][0] + v1 * m.value[2][1] + v2 * m.value[2][2] + v3 * m.value[2][3];
+      this->value[3] = v0 * m.value[3][0] + v1 * m.value[3][1] + v2 * m.value[3][2] + v3 * m.value[3][3];
         return *this;
     }
 
@@ -1787,7 +1818,7 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    tmat4x4<T> tmat4x4<T>::_inverse() {
+    tmat4x4<T> tmat4x4<T>::_inverse() const {
         auto& m = this->value;
 
 		T Coef00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
@@ -1846,7 +1877,7 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
-    tmat4x4<T> tmat4x4<T>::_tranpose() {
+    tmat4x4<T> tmat4x4<T>::_transpose() const {
 		tmat4x4 Transpose(detail::uninitialize);
         auto& m = this->value;
 
@@ -1871,6 +1902,90 @@ namespace LC_MINIMATH_NAMESPACE {
 		Transpose[3][3] = m[3][3];
 
 		return Transpose;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Operator: v*v
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tvec2<T> operator*(const tvec2<T>& v1, const tvec2<T>& v2) {
+        tvec2<T> result = v1;
+        result *= v2;
+        return result;
+    }
+
+    template <typename T> tvec3<T> operator*(const tvec3<T>& v1, const tvec3<T>& v2) {
+        tvec3<T> result = v1;
+        result *= v2;
+        return result;
+    }
+
+    template <typename T> tvec4<T> operator*(const tvec4<T>& v1, const tvec4<T>& v2) {
+        tvec4<T> result = v1;
+        result *= v2;
+        return result;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Operator: v/v
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tvec2<T> operator/(const tvec2<T>& v1, const tvec2<T>& v2) {
+        tvec2<T> result = v1;
+        result /= v2;
+        return result;
+    }
+
+    template <typename T> tvec3<T> operator/(const tvec3<T>& v1, const tvec3<T>& v2) {
+        tvec3<T> result = v1;
+        result /= v2;
+        return result;
+    }
+
+    template <typename T> tvec4<T> operator/(const tvec4<T>& v1, const tvec4<T>& v2) {
+        tvec4<T> result = v1;
+        result /= v2;
+        return result;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Operator: v+v
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tvec2<T> operator+(const tvec2<T>& v1, const tvec2<T>& v2) {
+        tvec2<T> result = v1;
+        result += v2;
+        return result;
+    }
+
+    template <typename T> tvec3<T> operator+(const tvec3<T>& v1, const tvec3<T>& v2) {
+        tvec3<T> result = v1;
+        result += v2;
+        return result;
+    }
+
+    template <typename T> tvec4<T> operator+(const tvec4<T>& v1, const tvec4<T>& v2) {
+        tvec4<T> result = v1;
+        result += v2;
+        return result;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Operator: v-v
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tvec2<T> operator-(const tvec2<T>& v1, const tvec2<T>& v2) {
+        tvec2<T> result = v1;
+        result -= v2;
+        return result;
+    }
+
+    template <typename T> tvec3<T> operator-(const tvec3<T>& v1, const tvec3<T>& v2) {
+        tvec3<T> result = v1;
+        result -= v2;
+        return result;
+    }
+
+    template <typename T> tvec4<T> operator-(const tvec4<T>& v1, const tvec4<T>& v2) {
+        tvec4<T> result = v1;
+        result -= v2;
+        return result;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -1913,40 +2028,61 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Operator: m*m
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tmat2x2<T> operator*(const tmat2x2<T>& m1, const tmat2x2<T>& m2) {
+      tmat2x2<T> result = m1;
+      result *= m2;
+      return result;
+    }
+
+    template <typename T> tmat3x3<T> operator*(const tmat3x3<T>& m1, const tmat3x3<T>& m2) {
+      tmat3x3<T> result = m1;
+      result *= m2;
+      return result;
+    }
+
+    template <typename T> tmat4x4<T> operator*(const tmat4x4<T>& m1, const tmat4x4<T>& m2) {
+      tmat4x4<T> result = m1;
+      result *= m2;
+      return result;
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Operator: m*s, s*m
     // ---------------------------------------------------------------------------------------------
     template <typename T, typename S> tmat2x2<T> operator*(const S& s, const tmat2x2<T>& m) {
-        tmat2x2<T> result = v;
+        tmat2x2<T> result = m;
         result *= s;
         return result;
     }
 
     template <typename T, typename S> tmat2x2<T> operator*(const tmat2x2<T>& m, const S& s) {
-        tmat2x2<T> result = v;
+        tmat2x2<T> result = m;
         result *= s;
         return result;
     }
 
     template <typename T, typename S> tmat3x3<T> operator*(const S& s, const tmat3x3<T>& m) {
-        tmat3x3<T> result = v;
+        tmat3x3<T> result = m;
         result *= s;
         return result;
     }
 
     template <typename T, typename S> tmat3x3<T> operator*(const tmat3x3<T>& m, const S& s) {
-        tmat3x3<T> result = v;
+        tmat3x3<T> result = m;
         result *= s;
         return result;
     }
 
     template <typename T, typename S> tmat4x4<T> operator*(const S& s, const tmat4x4<T>& m) {
-        tmat4x4<T> result = v;
+        tmat4x4<T> result = m;
         result *= s;
         return result;
     }
 
     template <typename T, typename S> tmat4x4<T> operator*(const tmat4x4<T>& m, const S& s) {
-        tmat4x4<T> result = v;
+        tmat4x4<T> result = m;
         result *= s;
         return result;
     }
@@ -1995,6 +2131,7 @@ namespace LC_MINIMATH_NAMESPACE {
 			m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z + m[2][3] * v.w,
 			m[3][0] * v.x + m[3][1] * v.y + m[3][2] * v.z + m[3][3] * v.w);
     }
+
 
     // ---------------------------------------------------------------------------------------------
     // Dot
@@ -2118,15 +2255,15 @@ namespace LC_MINIMATH_NAMESPACE {
     // Transpose
     // ---------------------------------------------------------------------------------------------
     template <typename T> tmat2x2<T> transpose(const tmat2x2<T>& m) {
-        return m._tranpose();
+        return m._transpose();
     }
 
     template <typename T> tmat3x3<T> transpose(const tmat3x3<T>& m) {
-        return m._tranpose();
+        return m._transpose();
     }
 
     template <typename T> tmat4x4<T> transpose(const tmat4x4<T>& m) {
-        return m._tranpose();
+        return m._transpose();
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -2134,9 +2271,9 @@ namespace LC_MINIMATH_NAMESPACE {
     // ---------------------------------------------------------------------------------------------
     template <typename T> tmat4x4<T> translate(const tvec3<T>& v) {
 		tmat4x4<T> Result;
-		Result[0][0] = v[0];
-		Result[1][1] = v[1];
-		Result[2][2] = v[2];
+        Result[3][0] = v[0];
+        Result[3][1] = v[1];
+        Result[3][2] = v[2];
 		return Result;
     }
 
@@ -2152,25 +2289,28 @@ namespace LC_MINIMATH_NAMESPACE {
 		Rotate[0][0] = c + temp[0] * axis[0];
 		Rotate[0][1] = temp[0] * axis[1] + s * axis[2];
 		Rotate[0][2] = temp[0] * axis[2] - s * axis[1];
+        Rotate[0][3] = 0.0f;
 
 		Rotate[1][0] = temp[1] * axis[0] - s * axis[2];
 		Rotate[1][1] = c + temp[1] * axis[1];
 		Rotate[1][2] = temp[1] * axis[2] + s * axis[0];
+        Rotate[1][3] = 0.0f;
 
 		Rotate[2][0] = temp[2] * axis[0] + s * axis[1];
 		Rotate[2][1] = temp[2] * axis[1] - s * axis[0];
 		Rotate[2][2] = c + temp[2] * axis[2];
+        Rotate[2][3] = 0.0f;
 
-		tmat4x4<T> Result(detail::uninitialize);
-		Result[0] = m[0] * Rotate[0][0] + m[1] * Rotate[0][1] + m[2] * Rotate[0][2];
-		Result[1] = m[0] * Rotate[1][0] + m[1] * Rotate[1][1] + m[2] * Rotate[1][2];
-		Result[2] = m[0] * Rotate[2][0] + m[1] * Rotate[2][1] + m[2] * Rotate[2][2];
-		Result[3] = m[3];
-		return Result;
+        Rotate[3][0] = 0.0f;
+        Rotate[3][1] = 0.0f;
+        Rotate[3][2] = 0.0f;
+        Rotate[3][3] = 1.0f;
+
+        return Rotate;
     }
 
     template <typename T> tmat4x4<T> scale(const tvec3<T>& v) {
-		tmat4x4<T> Result(uninitialize);
+        tmat4x4<T> Result(detail::uninitialize);
 		Result[0][0] = v[0];
 		Result[1][1] = v[1];
 		Result[2][2] = v[2];
@@ -2190,7 +2330,7 @@ namespace LC_MINIMATH_NAMESPACE {
 		tvec3<T> const s(normalize(cross(up, f)));
 		tvec3<T> const u(cross(f, s));
 
-		tmat4x4<T> Result();
+        tmat4x4<T> Result{};
 		Result[0][0] = s.x;
 		Result[1][0] = s.y;
 		Result[2][0] = s.z;
@@ -2211,7 +2351,7 @@ namespace LC_MINIMATH_NAMESPACE {
 		tvec3<T> const s(normalize(cross(f, up)));
 		tvec3<T> const u(cross(s, f));
 
-		tmat4x4<T> Result();
+        tmat4x4<T> Result{};
 		Result[0][0] = s.x;
 		Result[1][0] = s.y;
 		Result[2][0] = s.z;
@@ -2286,7 +2426,7 @@ namespace LC_MINIMATH_NAMESPACE {
 		assert(fov > static_cast<T>(0));
 	
 		T const rad = fov;
-		T const h = glm::cos(static_cast<T>(0.5) * rad) / glm::sin(static_cast<T>(0.5) * rad);
+        T const h = std::cos(static_cast<T>(0.5) * rad) / std::sin(static_cast<T>(0.5) * rad);
 		T const w = h * height / width; ///todo max(width , Height) / min(width , Height)?
 
 		tmat4x4<T> Result(static_cast<T>(0));
@@ -2311,7 +2451,7 @@ namespace LC_MINIMATH_NAMESPACE {
 		assert(fov > static_cast<T>(0));
 	
 		T const rad = fov;
-		T const h = glm::cos(static_cast<T>(0.5) * rad) / glm::sin(static_cast<T>(0.5) * rad);
+        T const h = std::cos(static_cast<T>(0.5) * rad) / std::sin(static_cast<T>(0.5) * rad);
 		T const w = h * height / width; ///todo max(width , Height) / min(width , Height)?
 
 		tmat4x4<T> Result(static_cast<T>(0));

--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -561,12 +561,12 @@ namespace LC_MINIMATH_NAMESPACE {
     template <typename T, typename S> tmat4x4<T> operator*(const tmat4x4<T>& m, const S& s);
 
     // Operator: m*v, v*m
-    template <typename T> tmat2x2<T> operator*(const tmat2x2<T>& m, const tvec2<T>& v);
-    template <typename T> tmat2x2<T> operator*(const tvec2<T>& v, const tmat2x2<T>& m);
-    template <typename T> tmat3x3<T> operator*(const tmat3x3<T>& m, const tvec3<T>& v);
-    template <typename T> tmat3x3<T> operator*(const tvec3<T>& v, const tmat3x3<T>& m);
-    template <typename T> tmat4x4<T> operator*(const tmat4x4<T>& m, const tvec4<T>& v);
-    template <typename T> tmat4x4<T> operator*(const tvec4<T>& v, const tmat4x4<T>& m);
+    template <typename T> typename tmat2x2<T>::col_type operator*(const tmat2x2<T>& m, const tvec2<T>& v);
+    template <typename T> typename tmat2x2<T>::row_type operator*(const tvec2<T>& v, const tmat2x2<T>& m);
+    template <typename T> typename tmat3x3<T>::col_type operator*(const tmat3x3<T>& m, const tvec3<T>& v);
+    template <typename T> typename tmat3x3<T>::row_type operator*(const tvec3<T>& v, const tmat3x3<T>& m);
+    template <typename T> typename tmat4x4<T>::col_type operator*(const tmat4x4<T>& m, const tvec4<T>& v);
+    template <typename T> typename tmat4x4<T>::row_type operator*(const tvec4<T>& v, const tmat4x4<T>& m);
 
     // Operator: m*m
     template <typename T> tmat2x2<T> operator*(const tmat2x2<T>& m1, const tmat2x2<T>& m2);
@@ -2131,42 +2131,42 @@ namespace LC_MINIMATH_NAMESPACE {
     // ---------------------------------------------------------------------------------------------
     // Operator: m*v, v*m
     // ---------------------------------------------------------------------------------------------
-    template <typename T> tmat2x2<T> operator*(const tmat2x2<T>& m, const tvec2<T>& v) {
+    template <typename T> typename tmat2x2<T>::col_type operator*(const tmat2x2<T>& m, const tvec2<T>& v) {
         return typename tmat2x2<T>::col_type(
             m[0][0] * v.x + m[1][0] * v.y,
             m[0][1] * v.x + m[1][1] * v.y);
     }
 
-    template <typename T> tmat2x2<T> operator*(const tvec2<T>& v, const tmat2x2<T>& m) {
-        return typename tmat3x3<T>::row_type(
+    template <typename T> typename tmat2x2<T>::row_type operator*(const tvec2<T>& v, const tmat2x2<T>& m) {
+        return typename tmat2x2<T>::row_type(
             m[0][0] * v.x + m[0][1] * v.y,
             m[1][0] * v.x + m[1][1] * v.y);
     }
 
-    template <typename T> tmat3x3<T> operator*(const tmat3x3<T>& m, const tvec3<T>& v) {
+    template <typename T> typename tmat3x3<T>::col_type operator*(const tmat3x3<T>& m, const tvec3<T>& v) {
         return typename tmat3x3<T>::col_type(
             m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z,
             m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z,
             m[0][2] * v.x + m[1][2] * v.y + m[2][2] * v.z);
     }
 
-    template <typename T> tmat3x3<T> operator*(const tvec3<T>& v, const tmat3x3<T>& m) {
+    template <typename T> typename tmat3x3<T>::row_type operator*(const tvec3<T>& v, const tmat3x3<T>& m) {
         return typename tmat3x3<T>::row_type(
             m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
             m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,
             m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z);
     }
 
-    template <typename T> tmat4x4<T> operator*(const tmat4x4<T>& m, const tvec4<T>& v) {
-        return typename tmat3x3<T>::col_type(
+    template <typename T> typename tmat4x4<T>::col_type operator*(const tmat4x4<T>& m, const tvec4<T>& v) {
+        return typename tmat4x4<T>::col_type(
             m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z + m[3][0] * v.w,
             m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z + m[3][1] * v.w,
             m[0][2] * v.x + m[1][2] * v.y + m[2][2] * v.z + m[3][2] * v.w,
             m[0][3] * v.x + m[1][3] * v.y + m[2][3] * v.z + m[3][3] * v.w);
     }
 
-    template <typename T> tmat4x4<T> operator*(const tvec4<T>& v, const tmat4x4<T>& m) {
-        return typename tmat3x3<T>::row_type(
+    template <typename T> typename tmat4x4<T>::row_type operator*(const tvec4<T>& v, const tmat4x4<T>& m) {
+        return typename tmat4x4<T>::row_type(
             m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z + m[0][3] * v.w,
             m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z + m[1][3] * v.w,
             m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z + m[2][3] * v.w,

--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -1373,8 +1373,10 @@ namespace LC_MINIMATH_NAMESPACE {
 
     template <typename T>
     tmat2x2<T>& tmat2x2<T>::operator*=(const tmat2x2<T>& m) {
-        this->value[0] *= m.value[0];
-        this->value[1] *= m.value[1];
+        const auto v0 = this->value[0];
+        const auto v1 = this->value[1];
+        this->value[0] = v0 * m.value[0][0] + v1 * m.value[0][1];
+        this->value[1] = v0 * m.value[1][0] + v1 * m.value[1][1];
         return *this;
     }
 
@@ -1569,9 +1571,12 @@ namespace LC_MINIMATH_NAMESPACE {
 
     template <typename T>
     tmat3x3<T>& tmat3x3<T>::operator*=(const tmat3x3<T>& m) {
-        this->value[0] *= m.value[0];
-        this->value[1] *= m.value[1];
-        this->value[2] *= m.value[2];
+        const auto v0 = this->value[0];
+        const auto v1 = this->value[1];
+        const auto v2 = this->value[2];
+        this->value[0] = v0 * m.value[0][0] + v1 * m.value[0][1] + v2 * m.value[0][2];
+        this->value[1] = v0 * m.value[1][0] + v1 * m.value[1][1] + v2 * m.value[1][2];
+        this->value[2] = v0 * m.value[2][0] + v1 * m.value[2][1] + v2 * m.value[2][2];
         return *this;
     }
 

--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -39,6 +39,7 @@ Large portions of lc_mini_math is borrowed from GLM:
     #error "C++ is required!"
 #endif
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <limits>
@@ -315,6 +316,8 @@ namespace LC_MINIMATH_NAMESPACE {
 
         tmat2x2();
 
+        explicit tmat2x2(const T& s);
+
         explicit tmat2x2(const T& x1, const T& y1,
                          const T& x2, const T& y2);
 
@@ -369,6 +372,8 @@ namespace LC_MINIMATH_NAMESPACE {
         tmat3x3(detail::ctor);
 
         tmat3x3();
+
+        explicit tmat3x3(const T& s);
 
         explicit tmat3x3(const T& x1, const T& y1, const T& z1,
                          const T& x2, const T& y2, const T& z2,
@@ -428,6 +433,8 @@ namespace LC_MINIMATH_NAMESPACE {
         tmat4x4(detail::ctor);
 
         tmat4x4();
+
+        explicit tmat4x4(const T& s);
 
         explicit tmat4x4(const T& x1, const T& y1, const T& z1, const T& w1,
                          const T& x2, const T& y2, const T& z2, const T& w2,
@@ -1263,6 +1270,13 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T>
+    tmat2x2<T>::tmat2x2(const T &s)
+    {
+      this->value[0] = col_type(s, 0);
+      this->value[1] = col_type(0, s);
+    }
+
+    template <typename T>
     tmat2x2<T>::tmat2x2(const T& x1, const T& y1,
                         const T& x2, const T& y2)
     {
@@ -1435,6 +1449,14 @@ namespace LC_MINIMATH_NAMESPACE {
         this->value[0] = col_type(1, 0, 0);
         this->value[1] = col_type(0, 1, 0);
         this->value[2] = col_type(0, 0, 1);
+    }
+
+    template <typename T>
+    tmat3x3<T>::tmat3x3(const T &s)
+    {
+        this->value[0] = col_type(s, 0, 0);
+        this->value[1] = col_type(0, s, 0);
+        this->value[2] = col_type(0, 0, s);
     }
 
     template <typename T>
@@ -1642,6 +1664,15 @@ namespace LC_MINIMATH_NAMESPACE {
         this->value[1] = col_type(0, 1, 0, 0);
         this->value[2] = col_type(0, 0, 1, 0);
         this->value[3] = col_type(0, 0, 0, 1);
+    }
+
+    template <typename T>
+    tmat4x4<T>::tmat4x4(const T &s)
+    {
+        this->value[0] = col_type(s, 0, 0, 0);
+        this->value[1] = col_type(0, s, 0, 0);
+        this->value[2] = col_type(0, 0, s, 0);
+        this->value[3] = col_type(0, 0, 0, s);
     }
 
     template <typename T>
@@ -2192,17 +2223,17 @@ namespace LC_MINIMATH_NAMESPACE {
     // Normalize
     // ---------------------------------------------------------------------------------------------
     template <typename T> tvec2<T> normalize(const tvec2<T>& v) {
-        T s = static_cast<T>(1) / dot(v, v);
+        T s = static_cast<T>(1) / length(v);
         return v * s;
     }
 
     template <typename T> tvec3<T> normalize(const tvec3<T>& v) {
-        T s = static_cast<T>(1) / dot(v, v);
+        T s = static_cast<T>(1) / length(v);
         return v * s;
     }
 
     template <typename T> tvec4<T> normalize(const tvec4<T>& v) {
-        T s = static_cast<T>(1) / dot(v, v);
+        T s = static_cast<T>(1) / length(v);
         return v * s;
     }
 

--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -606,6 +606,16 @@ namespace LC_MINIMATH_NAMESPACE {
     template <typename T> T distance2(const tvec3<T>& p0, const tvec3<T>& p1);
     template <typename T> T distance2(const tvec4<T>& p0, const tvec4<T>& p1);
 
+    // Min
+    template <typename T> tvec2<T> min(const tvec2<T>& p0, const tvec2<T>& p1);
+    template <typename T> tvec3<T> min(const tvec3<T>& p0, const tvec3<T>& p1);
+    template <typename T> tvec4<T> min(const tvec4<T>& p0, const tvec4<T>& p1);
+
+    // Max
+    template <typename T> tvec2<T> max(const tvec2<T>& p0, const tvec2<T>& p1);
+    template <typename T> tvec3<T> max(const tvec3<T>& p0, const tvec3<T>& p1);
+    template <typename T> tvec4<T> max(const tvec4<T>& p0, const tvec4<T>& p1);
+
     // Inverse
     template <typename T> tmat2x2<T> inverse(const tmat2x2<T>& m);
     template <typename T> tmat3x3<T> inverse(const tmat3x3<T>& m);
@@ -2265,6 +2275,48 @@ namespace LC_MINIMATH_NAMESPACE {
 
     template <typename T> T distance2(const tvec4<T>& p0, const tvec4<T>& p1) {
         return length2(p1 - p0);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Component-wise Min
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tvec2<T> min(const tvec2<T>& p0, const tvec2<T>& p1) {
+        return tvec2<T>(p0.x < p1.x ? p0.x : p1.x,
+                        p0.y < p1.y ? p0.y : p1.y);
+    }
+
+    template <typename T> tvec3<T> min(const tvec3<T>& p0, const tvec3<T>& p1) {
+        return tvec3<T>(p0.x < p1.x ? p0.x : p1.x,
+                        p0.y < p1.y ? p0.y : p1.y,
+                        p0.z < p1.z ? p0.z : p1.z);
+    }
+
+    template <typename T> tvec4<T> min(const tvec4<T>& p0, const tvec4<T>& p1) {
+        return tvec4<T>(p0.x < p1.x ? p0.x : p1.x,
+                        p0.y < p1.y ? p0.y : p1.y,
+                        p0.z < p1.z ? p0.z : p1.z,
+                        p0.w < p1.w ? p0.w : p1.w);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Component-wise Max
+    // ---------------------------------------------------------------------------------------------
+    template <typename T> tvec2<T> max(const tvec2<T>& p0, const tvec2<T>& p1) {
+        return tvec2<T>(p0.x > p1.x ? p0.x : p1.x,
+                        p0.y > p1.y ? p0.y : p1.y);
+    }
+
+    template <typename T> tvec3<T> max(const tvec3<T>& p0, const tvec3<T>& p1) {
+        return tvec3<T>(p0.x > p1.x ? p0.x : p1.x,
+                        p0.y > p1.y ? p0.y : p1.y,
+                        p0.z > p1.z ? p0.z : p1.z);
+    }
+
+    template <typename T> tvec4<T> max(const tvec4<T>& p0, const tvec4<T>& p1) {
+        return tvec4<T>(p0.x > p1.x ? p0.x : p1.x,
+                        p0.y > p1.y ? p0.y : p1.y,
+                        p0.z > p1.z ? p0.z : p1.z,
+                        p0.w > p1.w ? p0.w : p1.w);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/lc_mini_math.hpp
+++ b/lc_mini_math.hpp
@@ -37,7 +37,7 @@ Large portions of lc_mini_math is borrowed from GLM:
 
 #if ! defined(__cplusplus)
     #error "C++ is required!"
-#endif 
+#endif
 
 #include <cmath>
 #include <cstddef>
@@ -46,13 +46,13 @@ Large portions of lc_mini_math is borrowed from GLM:
 #define LC_DEPTH_ZERO_TO_ONE            0x00000001
 #define LC_DEPTH_NEGATIVE_ONE_TO_ONE    0x00000002
 
-#if ! defined(LC_DEPTH_CLIP_SPACE)
+#if ! defined( LC_DEPTH_CLIP_SPACE )
     #define LC_DEPTH_CLIP_SPACE         LC_DEPTH_ZERO_TO_ONE
 #endif
 
 #if ! defined( LC_MINIMATH_NAMESPACE )
     #define LC_MINIMATH_NAMESPACE lc
-#endif 
+#endif
 
 namespace LC_MINIMATH_NAMESPACE {
 
@@ -69,7 +69,7 @@ namespace LC_MINIMATH_NAMESPACE {
 
     //! \struct tvec2
     //!
-    //! 
+    //!
     template <typename T> struct tvec2 {
         using value_type = T;
 
@@ -82,7 +82,7 @@ namespace LC_MINIMATH_NAMESPACE {
         tvec2();
 
         explicit tvec2(T s);
-        explicit tvec2(T s1, 
+        explicit tvec2(T s1,
                        T s2);
         explicit tvec2(const tvec2<T>& v);
 
@@ -90,7 +90,7 @@ namespace LC_MINIMATH_NAMESPACE {
         tvec2(const X& s);
 
         template <typename X, typename Y>
-        tvec2(const X& s1, 
+        tvec2(const X& s1,
               const Y& s2);
 
         template <typename V>
@@ -128,7 +128,7 @@ namespace LC_MINIMATH_NAMESPACE {
 
     //! \struct tvec3
     //!
-    //! 
+    //!
     template <typename T> struct tvec3 {
         using value_type = T;
 
@@ -140,10 +140,10 @@ namespace LC_MINIMATH_NAMESPACE {
 
         tvec3();
         explicit tvec3(T s);
-        explicit tvec3(T s1, 
+        explicit tvec3(T s1,
                        T s2);
-        explicit tvec3(T s1, 
-                       T s2, 
+        explicit tvec3(T s1,
+                       T s2,
                        T s3);
         explicit tvec3(const tvec3<T>& v);
 
@@ -151,11 +151,11 @@ namespace LC_MINIMATH_NAMESPACE {
         tvec3(const X& s);
 
         template <typename X, typename Y>
-        tvec3(const X& s1, 
+        tvec3(const X& s1,
               const Y& s2);
 
         template <typename X, typename Y, typename Z>
-        tvec3(const X& s1, 
+        tvec3(const X& s1,
               const Y& s2,
               const Z& s3);
 
@@ -201,7 +201,7 @@ namespace LC_MINIMATH_NAMESPACE {
 
     //! \struct tvec4
     //!
-    //! 
+    //!
     template <typename T> struct tvec4 {
         using value_type = T;
 
@@ -213,14 +213,14 @@ namespace LC_MINIMATH_NAMESPACE {
 
         tvec4();
         explicit tvec4(T s);
-        explicit tvec4(T s1, 
+        explicit tvec4(T s1,
                        T s2);
-        explicit tvec4(T s1, 
-                       T s2, 
+        explicit tvec4(T s1,
+                       T s2,
                        T s3);
-        explicit tvec4(T s1, 
-                       T s2, 
-                       T s3, 
+        explicit tvec4(T s1,
+                       T s2,
+                       T s3,
                        T s4);
         explicit tvec4(const tvec4<T>& v);
 
@@ -228,16 +228,16 @@ namespace LC_MINIMATH_NAMESPACE {
         tvec4(const X& s);
 
         template <typename X, typename Y>
-        tvec4(const X& s1, 
+        tvec4(const X& s1,
               const Y& s2);
 
         template <typename X, typename Y, typename Z>
-        tvec4(const X& s1, 
+        tvec4(const X& s1,
               const Y& s2,
               const Z& s3);
 
         template <typename X, typename Y, typename Z, typename W>
-        tvec4(const X& s1, 
+        tvec4(const X& s1,
               const Y& s2,
               const Z& s3,
               const W& s4);
@@ -276,8 +276,8 @@ namespace LC_MINIMATH_NAMESPACE {
         tvec4(const tvec3<V>& v);
 
         template <typename V>
-        tvec4(const tvec4<V>& v);        
-        
+        tvec4(const tvec4<V>& v);
+
         tvec4<T>&   operator=(const tvec4<T>& v);
 
         template <typename U>
@@ -308,7 +308,7 @@ namespace LC_MINIMATH_NAMESPACE {
         using value_type = T;
         using col_type = tvec2<T>;
         using row_type = tvec2<T>;
-        
+
         col_type value[2];
 
         tmat2x2(detail::ctor);
@@ -320,7 +320,7 @@ namespace LC_MINIMATH_NAMESPACE {
 
         explicit tmat2x2(const col_type& v1,
                          const col_type& v2);
-        
+
         template <typename U>
         tmat2x2(const tvec2<U>& v1,
                 const tvec2<U>& v2);
@@ -363,7 +363,7 @@ namespace LC_MINIMATH_NAMESPACE {
         using value_type = T;
         using col_type = tvec3<T>;
         using row_type = tvec3<T>;
-        
+
         col_type value[3];
 
         tmat3x3(detail::ctor);
@@ -422,7 +422,7 @@ namespace LC_MINIMATH_NAMESPACE {
         using value_type = T;
         using col_type = tvec4<T>;
         using row_type = tvec4<T>;
-        
+
         col_type value[4];
 
         tmat4x4(detail::ctor);
@@ -632,47 +632,47 @@ namespace LC_MINIMATH_NAMESPACE {
     // tvec2
     // ---------------------------------------------------------------------------------------------
     template <typename T>
-    tvec2<T>::tvec2() : x(0), 
+    tvec2<T>::tvec2() : x(0),
                         y(0) {}
 
     template <typename T>
-    tvec2<T>::tvec2(T s) : x(s), 
-                           y(s) {}   
-    
+    tvec2<T>::tvec2(T s) : x(s),
+                           y(s) {}
+
     template <typename T>
-    tvec2<T>::tvec2(T s1, 
-                    T s2) : x(s1), 
+    tvec2<T>::tvec2(T s1,
+                    T s2) : x(s1),
                             y(s2) {}
-    
-    template <typename T>        
-    tvec2<T>::tvec2(const tvec2<T>& v) : x(v.x), 
+
+    template <typename T>
+    tvec2<T>::tvec2(const tvec2<T>& v) : x(v.x),
                                          y(v.y) {}
 
     template <typename T>
     template <typename X>
-    tvec2<T>::tvec2(const X& s) : x(static_cast<T>(s)), 
+    tvec2<T>::tvec2(const X& s) : x(static_cast<T>(s)),
                                   y(static_cast<T>(s)) {}
 
-    
+
     template <typename T>
     template <typename X, typename Y>
-    tvec2<T>::tvec2(const X& s1, 
-                    const Y& s2) : x(static_cast<T>(s1)), 
+    tvec2<T>::tvec2(const X& s1,
+                    const Y& s2) : x(static_cast<T>(s1)),
                                    y(static_cast<T>(s2)) {}
 
     template <typename T>
     template <typename V>
-    tvec2<T>::tvec2(const tvec2<V>& v) : x(static_cast<T>(v.x)), 
+    tvec2<T>::tvec2(const tvec2<V>& v) : x(static_cast<T>(v.x)),
                                          y(static_cast<T>(v.y)) {}
 
     template <typename T>
     template <typename V>
-    tvec2<T>::tvec2(const tvec3<V>& v) : x(static_cast<T>(v.x)), 
+    tvec2<T>::tvec2(const tvec3<V>& v) : x(static_cast<T>(v.x)),
                                          y(static_cast<T>(v.y)) {}
 
     template <typename T>
     template <typename V>
-    tvec2<T>::tvec2(const tvec4<V>& v) : x(static_cast<T>(v.x)), 
+    tvec2<T>::tvec2(const tvec4<V>& v) : x(static_cast<T>(v.x)),
                                          y(static_cast<T>(v.y)) {}
 
     template <typename T>
@@ -780,84 +780,84 @@ namespace LC_MINIMATH_NAMESPACE {
     // tvec3
     // ---------------------------------------------------------------------------------------------
     template <typename T>
-    tvec3<T>::tvec3() : x(0), 
+    tvec3<T>::tvec3() : x(0),
                         y(0),
                         z(0) {}
 
     template <typename T>
-    tvec3<T>::tvec3(T s) : x(s), 
+    tvec3<T>::tvec3(T s) : x(s),
                            y(s),
-                           z(s){}   
+                           z(s){}
 
     template <typename T>
-    tvec3<T>::tvec3(T s1, 
-                    T s2) : x(s1), 
+    tvec3<T>::tvec3(T s1,
+                    T s2) : x(s1),
                             y(s2),
                             z(0) {}
-    
+
     template <typename T>
-    tvec3<T>::tvec3(T s1, 
+    tvec3<T>::tvec3(T s1,
                     T s2,
-                    T s3) : x(s1), 
+                    T s3) : x(s1),
                             y(s2),
                             z(s3) {}
-    
-    template <typename T>        
-    tvec3<T>::tvec3(const tvec3<T>& v) : x(v.x), 
-                                         y(v.y), 
+
+    template <typename T>
+    tvec3<T>::tvec3(const tvec3<T>& v) : x(v.x),
+                                         y(v.y),
                                          z(v.z) {}
 
     template <typename T>
     template <typename X>
-    tvec3<T>::tvec3(const X& s) : x(static_cast<T>(s)), 
-                                  y(static_cast<T>(s)), 
+    tvec3<T>::tvec3(const X& s) : x(static_cast<T>(s)),
+                                  y(static_cast<T>(s)),
                                   z(static_cast<T>(s)) {}
 
     template <typename T>
     template <typename X, typename Y>
-    tvec3<T>::tvec3(const X& s1, 
-                    const Y& s2) : x(static_cast<T>(s1)), 
-                                   y(static_cast<T>(s2)), 
+    tvec3<T>::tvec3(const X& s1,
+                    const Y& s2) : x(static_cast<T>(s1)),
+                                   y(static_cast<T>(s2)),
                                    z(static_cast<T>(0)) {}
 
     template <typename T>
     template <typename X, typename Y, typename Z>
-    tvec3<T>::tvec3(const X& s1, 
-                    const Y& s2, 
-                    const Z& s3) : x(static_cast<T>(s1)), 
-                                   y(static_cast<T>(s2)), 
+    tvec3<T>::tvec3(const X& s1,
+                    const Y& s2,
+                    const Z& s3) : x(static_cast<T>(s1)),
+                                   y(static_cast<T>(s2)),
                                    z(static_cast<T>(s3)) {}
 
     template <typename T>
     template <typename V, typename S>
     tvec3<T>::tvec3(const tvec2<V>& v,
-                    const S&        s) : x(static_cast<T>(v.x)), 
-                                         y(static_cast<T>(v.y)), 
+                    const S&        s) : x(static_cast<T>(v.x)),
+                                         y(static_cast<T>(v.y)),
                                          z(static_cast<T>(s)) {}
 
     template <typename T>
     template <typename V, typename S>
     tvec3<T>::tvec3(const S&        s,
-                    const tvec2<V>& v) : x(static_cast<T>(s)), 
-                                         y(static_cast<T>(v.x)), 
+                    const tvec2<V>& v) : x(static_cast<T>(s)),
+                                         y(static_cast<T>(v.x)),
                                          z(static_cast<T>(v.y)) {}
 
     template <typename T>
     template <typename V>
-    tvec3<T>::tvec3(const tvec2<V>& v) : x(static_cast<T>(v.x)), 
+    tvec3<T>::tvec3(const tvec2<V>& v) : x(static_cast<T>(v.x)),
                                          y(static_cast<T>(v.y)),
                                          z(static_cast<T>(0.0)) {}
 
     template <typename T>
     template <typename V>
-    tvec3<T>::tvec3(const tvec3<V>& v) : x(static_cast<T>(v.x)), 
-                                         y(static_cast<T>(v.y)), 
+    tvec3<T>::tvec3(const tvec3<V>& v) : x(static_cast<T>(v.x)),
+                                         y(static_cast<T>(v.y)),
                                          z(static_cast<T>(v.z)) {}
 
     template <typename T>
     template <typename V>
-    tvec3<T>::tvec3(const tvec4<V>& v) : x(static_cast<T>(v.x)), 
-                                         y(static_cast<T>(v.y)), 
+    tvec3<T>::tvec3(const tvec4<V>& v) : x(static_cast<T>(v.x)),
+                                         y(static_cast<T>(v.y)),
                                          z(static_cast<T>(v.z)) {}
 
     template <typename T>
@@ -977,151 +977,151 @@ namespace LC_MINIMATH_NAMESPACE {
     // tvec4
     // ---------------------------------------------------------------------------------------------
     template <typename T>
-    tvec4<T>::tvec4() : x(0), 
+    tvec4<T>::tvec4() : x(0),
                         y(0),
                         z(0),
                         w(0) {}
 
     template <typename T>
-    tvec4<T>::tvec4(T s) : x(s), 
+    tvec4<T>::tvec4(T s) : x(s),
                            y(s),
                            z(s),
-                           w(s) {}        
+                           w(s) {}
 
     template <typename T>
-    tvec4<T>::tvec4(T s1, 
-                    T s2) : x(s1), 
+    tvec4<T>::tvec4(T s1,
+                    T s2) : x(s1),
                             y(s2),
                             z(0),
                             w(0) {}
-    
+
     template <typename T>
-    tvec4<T>::tvec4(T s1, 
+    tvec4<T>::tvec4(T s1,
                     T s2,
-                    T s3) : x(s1), 
+                    T s3) : x(s1),
                             y(s2),
                             z(s3),
                             w(0) {}
 
     template <typename T>
-    tvec4<T>::tvec4(T s1, 
+    tvec4<T>::tvec4(T s1,
                     T s2,
                     T s3,
-                    T s4) : x(s1), 
+                    T s4) : x(s1),
                             y(s2),
                             z(s3),
                             w(s4) {}
-    
-    template <typename T>        
-    tvec4<T>::tvec4(const tvec4<T>& v) : x(v.x), 
-                                         y(v.y), 
-                                         z(v.z), 
+
+    template <typename T>
+    tvec4<T>::tvec4(const tvec4<T>& v) : x(v.x),
+                                         y(v.y),
+                                         z(v.z),
                                          w(v.w) {}
 
     template <typename T>
     template <typename X>
-    tvec4<T>::tvec4(const X& s) : x(static_cast<T>(s)), 
-                                  y(static_cast<T>(s)), 
-                                  z(static_cast<T>(s)), 
+    tvec4<T>::tvec4(const X& s) : x(static_cast<T>(s)),
+                                  y(static_cast<T>(s)),
+                                  z(static_cast<T>(s)),
                                   w(static_cast<T>(s)) {}
 
     template <typename T>
     template <typename X, typename Y>
-    tvec4<T>::tvec4(const X& s1, 
-                    const Y& s2): x(static_cast<T>(s1)), 
-                                  y(static_cast<T>(s2)), 
-                                  z(static_cast<T>(0)), 
+    tvec4<T>::tvec4(const X& s1,
+                    const Y& s2): x(static_cast<T>(s1)),
+                                  y(static_cast<T>(s2)),
+                                  z(static_cast<T>(0)),
                                   w(static_cast<T>(0)) {}
 
     template <typename T>
     template <typename X, typename Y, typename Z>
-    tvec4<T>::tvec4(const X& s1, 
+    tvec4<T>::tvec4(const X& s1,
                     const Y& s2,
-                    const Z& s3): x(static_cast<T>(s1)), 
-                                  y(static_cast<T>(s2)), 
-                                  z(static_cast<T>(s3)), 
+                    const Z& s3): x(static_cast<T>(s1)),
+                                  y(static_cast<T>(s2)),
+                                  z(static_cast<T>(s3)),
                                   w(static_cast<T>(0)) {}
-    
+
     template <typename T>
     template <typename X, typename Y, typename Z, typename W>
-    tvec4<T>::tvec4(const X& s1, 
-                    const Y& s2, 
-                    const Z& s3, 
-                    const W& s4) : x(static_cast<T>(s1)), 
-                                   y(static_cast<T>(s2)), 
-                                   z(static_cast<T>(s3)), 
+    tvec4<T>::tvec4(const X& s1,
+                    const Y& s2,
+                    const Z& s3,
+                    const W& s4) : x(static_cast<T>(s1)),
+                                   y(static_cast<T>(s2)),
+                                   z(static_cast<T>(s3)),
                                    w(static_cast<T>(s4)) {}
 
     template <typename T>
     template <typename V, typename S1, typename S2>
     tvec4<T>::tvec4(const tvec2<V>& v,
                     const S1&       s1,
-                    const S2&       s2) : x(static_cast<T>(v.x)), 
-                                          y(static_cast<T>(v.y)), 
-                                          z(static_cast<T>(s1)), 
+                    const S2&       s2) : x(static_cast<T>(v.x)),
+                                          y(static_cast<T>(v.y)),
+                                          z(static_cast<T>(s1)),
                                           w(static_cast<T>(s2)) {}
 
     template <typename T>
     template <typename S1, typename V, typename S2>
     tvec4<T>::tvec4(const S1&       s1,
                     const tvec2<V>& v,
-                    const S2&       s2) : x(static_cast<T>(s1)), 
-                                          y(static_cast<T>(v.x)), 
-                                          z(static_cast<T>(v.y)), 
+                    const S2&       s2) : x(static_cast<T>(s1)),
+                                          y(static_cast<T>(v.x)),
+                                          z(static_cast<T>(v.y)),
                                           w(static_cast<T>(s2)) {}
 
     template <typename T>
     template <typename V, typename S1, typename S2>
     tvec4<T>::tvec4(const S1&       s1,
                     const S2&       s2,
-                    const tvec2<V>& v) : x(static_cast<T>(s1)), 
-                                         y(static_cast<T>(s2)), 
-                                         z(static_cast<T>(v.x)), 
+                    const tvec2<V>& v) : x(static_cast<T>(s1)),
+                                         y(static_cast<T>(s2)),
+                                         z(static_cast<T>(v.x)),
                                          w(static_cast<T>(v.y)) {}
 
     template <typename T>
     template <typename V1, typename V2>
     tvec4<T>::tvec4(const tvec2<V1>& v1,
-                    const tvec2<V2>& v2) : x(static_cast<T>(v1.x)), 
-                                           y(static_cast<T>(v1.y)), 
-                                           z(static_cast<T>(v2.x)), 
+                    const tvec2<V2>& v2) : x(static_cast<T>(v1.x)),
+                                           y(static_cast<T>(v1.y)),
+                                           z(static_cast<T>(v2.x)),
                                            w(static_cast<T>(v2.y)) {}
 
     template <typename T>
     template <typename V, typename S>
     tvec4<T>::tvec4(const tvec3<V>& v,
-                    const S&        s) : x(static_cast<T>(v.x)), 
-                                         y(static_cast<T>(v.y)), 
-                                         z(static_cast<T>(v.z)), 
+                    const S&        s) : x(static_cast<T>(v.x)),
+                                         y(static_cast<T>(v.y)),
+                                         z(static_cast<T>(v.z)),
                                          w(static_cast<T>(s)) {}
 
     template <typename T>
     template <typename S, typename V>
     tvec4<T>::tvec4(const S&        s,
-                    const tvec3<V>& v) : x(static_cast<T>(s)), 
-                                         y(static_cast<T>(v.x)), 
-                                         z(static_cast<T>(v.y)), 
+                    const tvec3<V>& v) : x(static_cast<T>(s)),
+                                         y(static_cast<T>(v.x)),
+                                         z(static_cast<T>(v.y)),
                                          w(static_cast<T>(v.z)) {}
 
     template <typename T>
     template <typename V>
-    tvec4<T>::tvec4(const tvec2<V>& v) : x(static_cast<T>(v.x)), 
+    tvec4<T>::tvec4(const tvec2<V>& v) : x(static_cast<T>(v.x)),
                                          y(static_cast<T>(v.y)),
                                          z(static_cast<T>(0)),
                                          w(static_cast<T>(0)) {}
 
     template <typename T>
     template <typename V>
-    tvec4<T>::tvec4(const tvec3<V>& v) : x(static_cast<T>(v.x)), 
-                                         y(static_cast<T>(v.y)), 
-                                         z(static_cast<T>(v.z)), 
+    tvec4<T>::tvec4(const tvec3<V>& v) : x(static_cast<T>(v.x)),
+                                         y(static_cast<T>(v.y)),
+                                         z(static_cast<T>(v.z)),
                                          w(static_cast<T>(0)) {}
 
     template <typename T>
     template <typename V>
-    tvec4<T>::tvec4(const tvec4<V>& v) : x(static_cast<T>(v.x)), 
-                                         y(static_cast<T>(v.y)), 
-                                         z(static_cast<T>(v.z)), 
+    tvec4<T>::tvec4(const tvec4<V>& v) : x(static_cast<T>(v.x)),
+                                         y(static_cast<T>(v.y)),
+                                         z(static_cast<T>(v.z)),
                                          w(static_cast<T>(v.w)) {}
 
     template <typename T>
@@ -1256,7 +1256,7 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat2x2<T>::tmat2x2(detail::ctor) {}
 
     template <typename T>
-    tmat2x2<T>::tmat2x2() 
+    tmat2x2<T>::tmat2x2()
     {
         this->value[0] = col_type(1, 0);
         this->value[1] = col_type(0, 1);
@@ -1264,7 +1264,7 @@ namespace LC_MINIMATH_NAMESPACE {
 
     template <typename T>
     tmat2x2<T>::tmat2x2(const T& x1, const T& y1,
-                        const T& x2, const T& y2) 
+                        const T& x2, const T& y2)
     {
         this->value[0] = col_type(x1, y1);
         this->value[1] = col_type(x2, y2);
@@ -1277,7 +1277,7 @@ namespace LC_MINIMATH_NAMESPACE {
         this->value[0] = v1;
         this->value[1] = v2;
     }
-        
+
     template <typename T>
     template <typename U>
     tmat2x2<T>::tmat2x2(const tvec2<U>& v1,
@@ -1397,30 +1397,30 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat2x2<T> tmat2x2<T>::_inverse() const {
         const auto& m = this->value;
 
-		T OneOverDeterminant = static_cast<T>(1) / (
-			+ m[0][0] * m[1][1]
-			- m[1][0] * m[0][1]);
+        T OneOverDeterminant = static_cast<T>(1) / (
+            + m[0][0] * m[1][1]
+            - m[1][0] * m[0][1]);
 
-		 tmat2x2 Inverse(
-			+ m[1][1] * OneOverDeterminant,
-			- m[0][1] * OneOverDeterminant,
-			- m[1][0] * OneOverDeterminant,
-			+ m[0][0] * OneOverDeterminant);
+         tmat2x2 Inverse(
+            + m[1][1] * OneOverDeterminant,
+            - m[0][1] * OneOverDeterminant,
+            - m[1][0] * OneOverDeterminant,
+            + m[0][0] * OneOverDeterminant);
 
         return Inverse;
     }
 
     template <typename T>
     tmat2x2<T> tmat2x2<T>::_transpose() const {
-		tmat2x2 Transpose(detail::uninitialize);
+        tmat2x2 Transpose(detail::uninitialize);
         const auto& m = this->value;
 
-		Transpose[0][0] = m[0][0];
-		Transpose[0][1] = m[1][0];
+        Transpose[0][0] = m[0][0];
+        Transpose[0][1] = m[1][0];
 
-		Transpose[1][0] = m[0][1];
-		Transpose[1][1] = m[1][1];
-		return Transpose;
+        Transpose[1][0] = m[0][1];
+        Transpose[1][1] = m[1][1];
+        return Transpose;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -1430,7 +1430,7 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat3x3<T>::tmat3x3(detail::ctor) {}
 
     template <typename T>
-    tmat3x3<T>::tmat3x3() 
+    tmat3x3<T>::tmat3x3()
     {
         this->value[0] = col_type(1, 0, 0);
         this->value[1] = col_type(0, 1, 0);
@@ -1440,7 +1440,7 @@ namespace LC_MINIMATH_NAMESPACE {
     template <typename T>
     tmat3x3<T>::tmat3x3(const T& x1, const T& y1, const T& z1,
                         const T& x2, const T& y2, const T& z2,
-                        const T& x3, const T& y3, const T& z3) 
+                        const T& x3, const T& y3, const T& z3)
     {
         this->value[0] = col_type(x1, y1, z1);
         this->value[1] = col_type(x2, y2, z2);
@@ -1456,7 +1456,7 @@ namespace LC_MINIMATH_NAMESPACE {
         this->value[1] = v2;
         this->value[2] = v3;
     }
-        
+
     template <typename T>
     template <typename U>
     tmat3x3<T>::tmat3x3(const tvec3<U>& v1,
@@ -1591,42 +1591,42 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat3x3<T> tmat3x3<T>::_inverse() const {
         auto& m = this->value;
 
-		T OneOverDeterminant = static_cast<T>(1) / (
-			+ m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2])
-			- m[1][0] * (m[0][1] * m[2][2] - m[2][1] * m[0][2])
-			+ m[2][0] * (m[0][1] * m[1][2] - m[1][1] * m[0][2]));
+        T OneOverDeterminant = static_cast<T>(1) / (
+            + m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2])
+            - m[1][0] * (m[0][1] * m[2][2] - m[2][1] * m[0][2])
+            + m[2][0] * (m[0][1] * m[1][2] - m[1][1] * m[0][2]));
 
-		tmat3x3 Inverse(detail::uninitialize);
-		Inverse[0][0] = + (m[1][1] * m[2][2] - m[2][1] * m[1][2]) * OneOverDeterminant;
-		Inverse[1][0] = - (m[1][0] * m[2][2] - m[2][0] * m[1][2]) * OneOverDeterminant;
-		Inverse[2][0] = + (m[1][0] * m[2][1] - m[2][0] * m[1][1]) * OneOverDeterminant;
-		Inverse[0][1] = - (m[0][1] * m[2][2] - m[2][1] * m[0][2]) * OneOverDeterminant;
-		Inverse[1][1] = + (m[0][0] * m[2][2] - m[2][0] * m[0][2]) * OneOverDeterminant;
-		Inverse[2][1] = - (m[0][0] * m[2][1] - m[2][0] * m[0][1]) * OneOverDeterminant;
-		Inverse[0][2] = + (m[0][1] * m[1][2] - m[1][1] * m[0][2]) * OneOverDeterminant;
-		Inverse[1][2] = - (m[0][0] * m[1][2] - m[1][0] * m[0][2]) * OneOverDeterminant;
-		Inverse[2][2] = + (m[0][0] * m[1][1] - m[1][0] * m[0][1]) * OneOverDeterminant;
+        tmat3x3 Inverse(detail::uninitialize);
+        Inverse[0][0] = + (m[1][1] * m[2][2] - m[2][1] * m[1][2]) * OneOverDeterminant;
+        Inverse[1][0] = - (m[1][0] * m[2][2] - m[2][0] * m[1][2]) * OneOverDeterminant;
+        Inverse[2][0] = + (m[1][0] * m[2][1] - m[2][0] * m[1][1]) * OneOverDeterminant;
+        Inverse[0][1] = - (m[0][1] * m[2][2] - m[2][1] * m[0][2]) * OneOverDeterminant;
+        Inverse[1][1] = + (m[0][0] * m[2][2] - m[2][0] * m[0][2]) * OneOverDeterminant;
+        Inverse[2][1] = - (m[0][0] * m[2][1] - m[2][0] * m[0][1]) * OneOverDeterminant;
+        Inverse[0][2] = + (m[0][1] * m[1][2] - m[1][1] * m[0][2]) * OneOverDeterminant;
+        Inverse[1][2] = - (m[0][0] * m[1][2] - m[1][0] * m[0][2]) * OneOverDeterminant;
+        Inverse[2][2] = + (m[0][0] * m[1][1] - m[1][0] * m[0][1]) * OneOverDeterminant;
 
-		return Inverse;
+        return Inverse;
     }
 
     template <typename T>
     tmat3x3<T> tmat3x3<T>::_transpose() const {
-		tmat3x3 Transpose(detail::uninitialize);
+        tmat3x3 Transpose(detail::uninitialize);
         const auto& m = this->value;
 
-		Transpose[0][0] = m[0][0];
-		Transpose[0][1] = m[1][0];
-		Transpose[0][2] = m[2][0];
+        Transpose[0][0] = m[0][0];
+        Transpose[0][1] = m[1][0];
+        Transpose[0][2] = m[2][0];
 
-		Transpose[1][0] = m[0][1];
-		Transpose[1][1] = m[1][1];
-		Transpose[1][2] = m[2][1];
+        Transpose[1][0] = m[0][1];
+        Transpose[1][1] = m[1][1];
+        Transpose[1][2] = m[2][1];
 
-		Transpose[2][0] = m[0][2];
-		Transpose[2][1] = m[1][2];
-		Transpose[2][2] = m[2][2];
-		return Transpose;
+        Transpose[2][0] = m[0][2];
+        Transpose[2][1] = m[1][2];
+        Transpose[2][2] = m[2][2];
+        return Transpose;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -1636,7 +1636,7 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat4x4<T>::tmat4x4(detail::ctor) {}
 
     template <typename T>
-    tmat4x4<T>::tmat4x4() 
+    tmat4x4<T>::tmat4x4()
     {
         this->value[0] = col_type(1, 0, 0, 0);
         this->value[1] = col_type(0, 1, 0, 0);
@@ -1648,7 +1648,7 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat4x4<T>::tmat4x4(const T& x1, const T& y1, const T& z1, const T& w1,
                         const T& x2, const T& y2, const T& z2, const T& w2,
                         const T& x3, const T& y3, const T& z3, const T& w3,
-                        const T& x4, const T& y4, const T& z4, const T& w4) 
+                        const T& x4, const T& y4, const T& z4, const T& w4)
     {
         this->value[0] = col_type(x1, y1, z1, w1);
         this->value[1] = col_type(x2, y2, z2, w2);
@@ -1667,7 +1667,7 @@ namespace LC_MINIMATH_NAMESPACE {
         this->value[2] = v3;
         this->value[3] = v4;
     }
-        
+
     template <typename T>
     template <typename U>
     tmat4x4<T>::tmat4x4(const tvec4<U>& v1,
@@ -1765,7 +1765,7 @@ namespace LC_MINIMATH_NAMESPACE {
       this->value[1] = v0 * m.value[1][0] + v1 * m.value[1][1] + v2 * m.value[1][2] + v3 * m.value[1][3];
       this->value[2] = v0 * m.value[2][0] + v1 * m.value[2][1] + v2 * m.value[2][2] + v3 * m.value[2][3];
       this->value[3] = v0 * m.value[3][0] + v1 * m.value[3][1] + v2 * m.value[3][2] + v3 * m.value[3][3];
-        return *this;
+      return *this;
     }
 
     template <typename T>
@@ -1821,87 +1821,87 @@ namespace LC_MINIMATH_NAMESPACE {
     tmat4x4<T> tmat4x4<T>::_inverse() const {
         auto& m = this->value;
 
-		T Coef00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
-		T Coef02 = m[1][2] * m[3][3] - m[3][2] * m[1][3];
-		T Coef03 = m[1][2] * m[2][3] - m[2][2] * m[1][3];
+        T Coef00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
+        T Coef02 = m[1][2] * m[3][3] - m[3][2] * m[1][3];
+        T Coef03 = m[1][2] * m[2][3] - m[2][2] * m[1][3];
 
-		T Coef04 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
-		T Coef06 = m[1][1] * m[3][3] - m[3][1] * m[1][3];
-		T Coef07 = m[1][1] * m[2][3] - m[2][1] * m[1][3];
+        T Coef04 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
+        T Coef06 = m[1][1] * m[3][3] - m[3][1] * m[1][3];
+        T Coef07 = m[1][1] * m[2][3] - m[2][1] * m[1][3];
 
-		T Coef08 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
-		T Coef10 = m[1][1] * m[3][2] - m[3][1] * m[1][2];
-		T Coef11 = m[1][1] * m[2][2] - m[2][1] * m[1][2];
+        T Coef08 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
+        T Coef10 = m[1][1] * m[3][2] - m[3][1] * m[1][2];
+        T Coef11 = m[1][1] * m[2][2] - m[2][1] * m[1][2];
 
-		T Coef12 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
-		T Coef14 = m[1][0] * m[3][3] - m[3][0] * m[1][3];
-		T Coef15 = m[1][0] * m[2][3] - m[2][0] * m[1][3];
+        T Coef12 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
+        T Coef14 = m[1][0] * m[3][3] - m[3][0] * m[1][3];
+        T Coef15 = m[1][0] * m[2][3] - m[2][0] * m[1][3];
 
-		T Coef16 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
-		T Coef18 = m[1][0] * m[3][2] - m[3][0] * m[1][2];
-		T Coef19 = m[1][0] * m[2][2] - m[2][0] * m[1][2];
+        T Coef16 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
+        T Coef18 = m[1][0] * m[3][2] - m[3][0] * m[1][2];
+        T Coef19 = m[1][0] * m[2][2] - m[2][0] * m[1][2];
 
-		T Coef20 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
-		T Coef22 = m[1][0] * m[3][1] - m[3][0] * m[1][1];
-		T Coef23 = m[1][0] * m[2][1] - m[2][0] * m[1][1];
+        T Coef20 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
+        T Coef22 = m[1][0] * m[3][1] - m[3][0] * m[1][1];
+        T Coef23 = m[1][0] * m[2][1] - m[2][0] * m[1][1];
 
-		tvec4<T> Fac0(Coef00, Coef00, Coef02, Coef03);
-		tvec4<T> Fac1(Coef04, Coef04, Coef06, Coef07);
-		tvec4<T> Fac2(Coef08, Coef08, Coef10, Coef11);
-		tvec4<T> Fac3(Coef12, Coef12, Coef14, Coef15);
-		tvec4<T> Fac4(Coef16, Coef16, Coef18, Coef19);
-		tvec4<T> Fac5(Coef20, Coef20, Coef22, Coef23);
+        tvec4<T> Fac0(Coef00, Coef00, Coef02, Coef03);
+        tvec4<T> Fac1(Coef04, Coef04, Coef06, Coef07);
+        tvec4<T> Fac2(Coef08, Coef08, Coef10, Coef11);
+        tvec4<T> Fac3(Coef12, Coef12, Coef14, Coef15);
+        tvec4<T> Fac4(Coef16, Coef16, Coef18, Coef19);
+        tvec4<T> Fac5(Coef20, Coef20, Coef22, Coef23);
 
-		tvec4<T> Vec0(m[1][0], m[0][0], m[0][0], m[0][0]);
-		tvec4<T> Vec1(m[1][1], m[0][1], m[0][1], m[0][1]);
-		tvec4<T> Vec2(m[1][2], m[0][2], m[0][2], m[0][2]);
-		tvec4<T> Vec3(m[1][3], m[0][3], m[0][3], m[0][3]);
+        tvec4<T> Vec0(m[1][0], m[0][0], m[0][0], m[0][0]);
+        tvec4<T> Vec1(m[1][1], m[0][1], m[0][1], m[0][1]);
+        tvec4<T> Vec2(m[1][2], m[0][2], m[0][2], m[0][2]);
+        tvec4<T> Vec3(m[1][3], m[0][3], m[0][3], m[0][3]);
 
-		tvec4<T> Inv0(Vec1 * Fac0 - Vec2 * Fac1 + Vec3 * Fac2);
-		tvec4<T> Inv1(Vec0 * Fac0 - Vec2 * Fac3 + Vec3 * Fac4);
-		tvec4<T> Inv2(Vec0 * Fac1 - Vec1 * Fac3 + Vec3 * Fac5);
-		tvec4<T> Inv3(Vec0 * Fac2 - Vec1 * Fac4 + Vec2 * Fac5);
+        tvec4<T> Inv0(Vec1 * Fac0 - Vec2 * Fac1 + Vec3 * Fac2);
+        tvec4<T> Inv1(Vec0 * Fac0 - Vec2 * Fac3 + Vec3 * Fac4);
+        tvec4<T> Inv2(Vec0 * Fac1 - Vec1 * Fac3 + Vec3 * Fac5);
+        tvec4<T> Inv3(Vec0 * Fac2 - Vec1 * Fac4 + Vec2 * Fac5);
 
-		tvec4<T> SignA(+1, -1, +1, -1);
-		tvec4<T> SignB(-1, +1, -1, +1);
-		tmat4x4 Inverse(Inv0 * SignA, Inv1 * SignB, Inv2 * SignA, Inv3 * SignB);
+        tvec4<T> SignA(+1, -1, +1, -1);
+        tvec4<T> SignB(-1, +1, -1, +1);
+        tmat4x4 Inverse(Inv0 * SignA, Inv1 * SignB, Inv2 * SignA, Inv3 * SignB);
 
-		tvec4<T> Row0(Inverse[0][0], Inverse[1][0], Inverse[2][0], Inverse[3][0]);
+        tvec4<T> Row0(Inverse[0][0], Inverse[1][0], Inverse[2][0], Inverse[3][0]);
 
-		tvec4<T> Dot0(m[0] * Row0);
-		T Dot1 = (Dot0.x + Dot0.y) + (Dot0.z + Dot0.w);
+        tvec4<T> Dot0(m[0] * Row0);
+        T Dot1 = (Dot0.x + Dot0.y) + (Dot0.z + Dot0.w);
 
-		T OneOverDeterminant = static_cast<T>(1) / Dot1;
+        T OneOverDeterminant = static_cast<T>(1) / Dot1;
 
-		return Inverse * OneOverDeterminant;
+        return Inverse * OneOverDeterminant;
     }
 
     template <typename T>
     tmat4x4<T> tmat4x4<T>::_transpose() const {
-		tmat4x4 Transpose(detail::uninitialize);
+        tmat4x4 Transpose(detail::uninitialize);
         auto& m = this->value;
 
-		Transpose[0][0] = m[0][0];
-		Transpose[0][1] = m[1][0];
-		Transpose[0][2] = m[2][0];
-		Transpose[0][3] = m[3][0];
+        Transpose[0][0] = m[0][0];
+        Transpose[0][1] = m[1][0];
+        Transpose[0][2] = m[2][0];
+        Transpose[0][3] = m[3][0];
 
-		Transpose[1][0] = m[0][1];
-		Transpose[1][1] = m[1][1];
-		Transpose[1][2] = m[2][1];
-		Transpose[1][3] = m[3][1];
+        Transpose[1][0] = m[0][1];
+        Transpose[1][1] = m[1][1];
+        Transpose[1][2] = m[2][1];
+        Transpose[1][3] = m[3][1];
 
-		Transpose[2][0] = m[0][2];
-		Transpose[2][1] = m[1][2];
-		Transpose[2][2] = m[2][2];
-		Transpose[2][3] = m[3][2];
+        Transpose[2][0] = m[0][2];
+        Transpose[2][1] = m[1][2];
+        Transpose[2][2] = m[2][2];
+        Transpose[2][3] = m[3][2];
 
-		Transpose[3][0] = m[0][3];
-		Transpose[3][1] = m[1][3];
-		Transpose[3][2] = m[2][3];
-		Transpose[3][3] = m[3][3];
+        Transpose[3][0] = m[0][3];
+        Transpose[3][1] = m[1][3];
+        Transpose[3][2] = m[2][3];
+        Transpose[3][3] = m[3][3];
 
-		return Transpose;
+        return Transpose;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -2086,50 +2086,50 @@ namespace LC_MINIMATH_NAMESPACE {
         result *= s;
         return result;
     }
-    
+
     // ---------------------------------------------------------------------------------------------
     // Operator: m*v, v*m
     // ---------------------------------------------------------------------------------------------
     template <typename T> tmat2x2<T> operator*(const tmat2x2<T>& m, const tvec2<T>& v) {
-	    return typename tmat2x2<T>::col_type(
-		    m[0][0] * v.x + m[1][0] * v.y,
-		    m[0][1] * v.x + m[1][1] * v.y);
+        return typename tmat2x2<T>::col_type(
+            m[0][0] * v.x + m[1][0] * v.y,
+            m[0][1] * v.x + m[1][1] * v.y);
     }
 
     template <typename T> tmat2x2<T> operator*(const tvec2<T>& v, const tmat2x2<T>& m) {
-		return typename tmat3x3<T>::row_type(
-			m[0][0] * v.x + m[0][1] * v.y,
-			m[1][0] * v.x + m[1][1] * v.y);
+        return typename tmat3x3<T>::row_type(
+            m[0][0] * v.x + m[0][1] * v.y,
+            m[1][0] * v.x + m[1][1] * v.y);
     }
-    
+
     template <typename T> tmat3x3<T> operator*(const tmat3x3<T>& m, const tvec3<T>& v) {
-	    return typename tmat3x3<T>::col_type(
-		    m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z,
-		    m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z,
-		    m[0][2] * v.x + m[1][2] * v.y + m[2][2] * v.z);
+        return typename tmat3x3<T>::col_type(
+            m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z,
+            m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z,
+            m[0][2] * v.x + m[1][2] * v.y + m[2][2] * v.z);
     }
 
     template <typename T> tmat3x3<T> operator*(const tvec3<T>& v, const tmat3x3<T>& m) {
-		return typename tmat3x3<T>::row_type(
-			m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
-			m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,
-			m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z);
+        return typename tmat3x3<T>::row_type(
+            m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
+            m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,
+            m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z);
     }
 
     template <typename T> tmat4x4<T> operator*(const tmat4x4<T>& m, const tvec4<T>& v) {
-	    return typename tmat3x3<T>::col_type(
-		    m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z + m[3][0] * v.w,
-		    m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z + m[3][1] * v.w,
-		    m[0][2] * v.x + m[1][2] * v.y + m[2][2] * v.z + m[3][2] * v.w,
-		    m[0][3] * v.x + m[1][3] * v.y + m[2][3] * v.z + m[3][3] * v.w);
+        return typename tmat3x3<T>::col_type(
+            m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z + m[3][0] * v.w,
+            m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z + m[3][1] * v.w,
+            m[0][2] * v.x + m[1][2] * v.y + m[2][2] * v.z + m[3][2] * v.w,
+            m[0][3] * v.x + m[1][3] * v.y + m[2][3] * v.z + m[3][3] * v.w);
     }
 
-    template <typename T> tmat4x4<T> operator*(const tvec4<T>& v, const tmat4x4<T>& m){
-		return typename tmat3x3<T>::row_type(
-			m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z + m[0][3] * v.w,
-			m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z + m[1][3] * v.w,
-			m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z + m[2][3] * v.w,
-			m[3][0] * v.x + m[3][1] * v.y + m[3][2] * v.z + m[3][3] * v.w);
+    template <typename T> tmat4x4<T> operator*(const tvec4<T>& v, const tmat4x4<T>& m) {
+        return typename tmat3x3<T>::row_type(
+            m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z + m[0][3] * v.w,
+            m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z + m[1][3] * v.w,
+            m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z + m[2][3] * v.w,
+            m[3][0] * v.x + m[3][1] * v.y + m[3][2] * v.z + m[3][3] * v.w);
     }
 
 
@@ -2152,10 +2152,10 @@ namespace LC_MINIMATH_NAMESPACE {
     // Cross Product
     // ---------------------------------------------------------------------------------------------
     template <typename T> tvec3<T> cross(const tvec3<T>& v1, const tvec3<T>& v2) {
-		return tvec3<T>(
-			v1.y * v2.z - v2.y * v1.z,
-			v1.z * v2.x - v2.z * v1.x,
-			v1.x * v2.y - v2.x * v1.y);
+        return tvec3<T>(
+            v1.y * v2.z - v2.y * v1.z,
+            v1.z * v2.x - v2.z * v1.x,
+            v1.x * v2.y - v2.x * v1.y);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -2172,7 +2172,7 @@ namespace LC_MINIMATH_NAMESPACE {
     template <typename T> T length(const tvec4<T>& v) {
         return sqrt(dot(v, v));
     }
-    
+
     // ---------------------------------------------------------------------------------------------
     // LengthSquared
     // ---------------------------------------------------------------------------------------------
@@ -2270,35 +2270,35 @@ namespace LC_MINIMATH_NAMESPACE {
     // Translate, Rotate, Scale
     // ---------------------------------------------------------------------------------------------
     template <typename T> tmat4x4<T> translate(const tvec3<T>& v) {
-		tmat4x4<T> Result;
+        tmat4x4<T> Result;
         Result[3][0] = v[0];
         Result[3][1] = v[1];
         Result[3][2] = v[2];
-		return Result;
+        return Result;
     }
 
     template <typename T> tmat4x4<T> rotate(const T& angle, const tvec3<T>& v) {
-		T const a = angle;
-		T const c = cos(a);
-		T const s = sin(a);
+        T const a = angle;
+        T const c = cos(a);
+        T const s = sin(a);
 
-		tvec3<T> axis(normalize(v));
-		tvec3<T> temp((T(1) - c) * axis);
+        tvec3<T> axis(normalize(v));
+        tvec3<T> temp((T(1) - c) * axis);
 
-		tmat4x4<T> Rotate(detail::uninitialize);
-		Rotate[0][0] = c + temp[0] * axis[0];
-		Rotate[0][1] = temp[0] * axis[1] + s * axis[2];
-		Rotate[0][2] = temp[0] * axis[2] - s * axis[1];
+        tmat4x4<T> Rotate(detail::uninitialize);
+        Rotate[0][0] = c + temp[0] * axis[0];
+        Rotate[0][1] = temp[0] * axis[1] + s * axis[2];
+        Rotate[0][2] = temp[0] * axis[2] - s * axis[1];
         Rotate[0][3] = 0.0f;
 
-		Rotate[1][0] = temp[1] * axis[0] - s * axis[2];
-		Rotate[1][1] = c + temp[1] * axis[1];
-		Rotate[1][2] = temp[1] * axis[2] + s * axis[0];
+        Rotate[1][0] = temp[1] * axis[0] - s * axis[2];
+        Rotate[1][1] = c + temp[1] * axis[1];
+        Rotate[1][2] = temp[1] * axis[2] + s * axis[0];
         Rotate[1][3] = 0.0f;
 
-		Rotate[2][0] = temp[2] * axis[0] + s * axis[1];
-		Rotate[2][1] = temp[2] * axis[1] - s * axis[0];
-		Rotate[2][2] = c + temp[2] * axis[2];
+        Rotate[2][0] = temp[2] * axis[0] + s * axis[1];
+        Rotate[2][1] = temp[2] * axis[1] - s * axis[0];
+        Rotate[2][2] = c + temp[2] * axis[2];
         Rotate[2][3] = 0.0f;
 
         Rotate[3][0] = 0.0f;
@@ -2311,11 +2311,11 @@ namespace LC_MINIMATH_NAMESPACE {
 
     template <typename T> tmat4x4<T> scale(const tvec3<T>& v) {
         tmat4x4<T> Result(detail::uninitialize);
-		Result[0][0] = v[0];
-		Result[1][1] = v[1];
-		Result[2][2] = v[2];
-		Result[3][3] = static_cast<T>(1);
-		return Result;
+        Result[0][0] = v[0];
+        Result[1][1] = v[1];
+        Result[2][2] = v[2];
+        Result[3][3] = static_cast<T>(1);
+        return Result;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -2326,45 +2326,45 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T> tmat4x4<T> lookAtLH(const tvec3<T>& eye, const tvec3<T>& center, const tvec3<T>& up) {
-		tvec3<T> const f(normalize(center - eye));
-		tvec3<T> const s(normalize(cross(up, f)));
-		tvec3<T> const u(cross(f, s));
+        tvec3<T> const f(normalize(center - eye));
+        tvec3<T> const s(normalize(cross(up, f)));
+        tvec3<T> const u(cross(f, s));
 
         tmat4x4<T> Result{};
-		Result[0][0] = s.x;
-		Result[1][0] = s.y;
-		Result[2][0] = s.z;
-		Result[0][1] = u.x;
-		Result[1][1] = u.y;
-		Result[2][1] = u.z;
-		Result[0][2] = f.x;
-		Result[1][2] = f.y;
-		Result[2][2] = f.z;
-		Result[3][0] = -dot(s, eye);
-		Result[3][1] = -dot(u, eye);
-		Result[3][2] = -dot(f, eye);
-		return Result;
+        Result[0][0] = s.x;
+        Result[1][0] = s.y;
+        Result[2][0] = s.z;
+        Result[0][1] = u.x;
+        Result[1][1] = u.y;
+        Result[2][1] = u.z;
+        Result[0][2] = f.x;
+        Result[1][2] = f.y;
+        Result[2][2] = f.z;
+        Result[3][0] = -dot(s, eye);
+        Result[3][1] = -dot(u, eye);
+        Result[3][2] = -dot(f, eye);
+        return Result;
     }
 
     template <typename T> tmat4x4<T> lookAtRH(const tvec3<T>& eye, const tvec3<T>& center, const tvec3<T>& up) {
-		tvec3<T> const f(normalize(center - eye));
-		tvec3<T> const s(normalize(cross(f, up)));
-		tvec3<T> const u(cross(s, f));
+        tvec3<T> const f(normalize(center - eye));
+        tvec3<T> const s(normalize(cross(f, up)));
+        tvec3<T> const u(cross(s, f));
 
         tmat4x4<T> Result{};
-		Result[0][0] = s.x;
-		Result[1][0] = s.y;
-		Result[2][0] = s.z;
-		Result[0][1] = u.x;
-		Result[1][1] = u.y;
-		Result[2][1] = u.z;
-		Result[0][2] =-f.x;
-		Result[1][2] =-f.y;
-		Result[2][2] =-f.z;
-		Result[3][0] =-dot(s, eye);
-		Result[3][1] =-dot(u, eye);
-		Result[3][2] = dot(f, eye);
-		return Result;
+        Result[0][0] = s.x;
+        Result[1][0] = s.y;
+        Result[2][0] = s.z;
+        Result[0][1] = u.x;
+        Result[1][1] = u.y;
+        Result[2][1] = u.z;
+        Result[0][2] =-f.x;
+        Result[1][2] =-f.y;
+        Result[2][2] =-f.z;
+        Result[3][0] =-dot(s, eye);
+        Result[3][1] =-dot(u, eye);
+        Result[3][2] = dot(f, eye);
+        return Result;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -2375,45 +2375,45 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T> tmat4x4<T> perspectiveLH(T fovy, T aspect, T zNear, T zFar) {
-		assert(abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
+        assert(abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
 
-		T const tanHalfFovy = tan(fovy / static_cast<T>(2));
-		
-		tmat4x4<T> Result(static_cast<T>(0));
-		Result[0][0] = static_cast<T>(1) / (aspect * tanHalfFovy);
-		Result[1][1] = static_cast<T>(1) / (tanHalfFovy);
-		Result[2][3] = static_cast<T>(1);
+        T const tanHalfFovy = tan(fovy / static_cast<T>(2));
+
+        tmat4x4<T> Result(static_cast<T>(0));
+        Result[0][0] = static_cast<T>(1) / (aspect * tanHalfFovy);
+        Result[1][1] = static_cast<T>(1) / (tanHalfFovy);
+        Result[2][3] = static_cast<T>(1);
 
 #if (LC_DEPTH_CLIP_SPACE == LC_DEPTH_ZERO_TO_ONE)
-		Result[2][2] = zFar / (zFar - zNear);
-		Result[3][2] = -(zFar * zNear) / (zFar - zNear);
+        Result[2][2] = zFar / (zFar - zNear);
+        Result[3][2] = -(zFar * zNear) / (zFar - zNear);
 #else
-		Result[2][2] = (zFar + zNear) / (zFar - zNear);
-		Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
+        Result[2][2] = (zFar + zNear) / (zFar - zNear);
+        Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
 #endif
 
-		return Result;
+        return Result;
     }
 
     template <typename T> tmat4x4<T> perspectiveRH(T fovy, T aspect, T zNear, T zFar) {
-		assert(abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
+        assert(abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
 
-		T const tanHalfFovy = tan(fovy / static_cast<T>(2));
+        T const tanHalfFovy = tan(fovy / static_cast<T>(2));
 
-		tmat4x4<T> Result(static_cast<T>(0));
-		Result[0][0] = static_cast<T>(1) / (aspect * tanHalfFovy);
-		Result[1][1] = static_cast<T>(1) / (tanHalfFovy);
-		Result[2][3] = -static_cast<T>(1);
+        tmat4x4<T> Result(static_cast<T>(0));
+        Result[0][0] = static_cast<T>(1) / (aspect * tanHalfFovy);
+        Result[1][1] = static_cast<T>(1) / (tanHalfFovy);
+        Result[2][3] = -static_cast<T>(1);
 
 #if (LC_DEPTH_CLIP_SPACE == LC_DEPTH_ZERO_TO_ONE)
-		Result[2][2] = zFar / (zNear - zFar);
-		Result[3][2] = -(zFar * zNear) / (zFar - zNear);
+        Result[2][2] = zFar / (zNear - zFar);
+        Result[3][2] = -(zFar * zNear) / (zFar - zNear);
 #else
-		Result[2][2] = - (zFar + zNear) / (zFar - zNear);
-		Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
+        Result[2][2] = - (zFar + zNear) / (zFar - zNear);
+        Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
 #endif
 
-		return Result;
+        return Result;
     }
 
     template <typename T> tmat4x4<T> perspectiveFov(T fov, T width, T height, T zNear, T zFar) {
@@ -2421,53 +2421,53 @@ namespace LC_MINIMATH_NAMESPACE {
     }
 
     template <typename T> tmat4x4<T> perspectiveFovLH(T fov, T width, T height, T zNear, T zFar) {
-		assert(width > static_cast<T>(0));
-		assert(height > static_cast<T>(0));
-		assert(fov > static_cast<T>(0));
-	
-		T const rad = fov;
-        T const h = std::cos(static_cast<T>(0.5) * rad) / std::sin(static_cast<T>(0.5) * rad);
-		T const w = h * height / width; ///todo max(width , Height) / min(width , Height)?
+        assert(width > static_cast<T>(0));
+        assert(height > static_cast<T>(0));
+        assert(fov > static_cast<T>(0));
 
-		tmat4x4<T> Result(static_cast<T>(0));
-		Result[0][0] = w;
-		Result[1][1] = h;
-		Result[2][3] = static_cast<T>(1);
+        T const rad = fov;
+        T const h = std::cos(static_cast<T>(0.5) * rad) / std::sin(static_cast<T>(0.5) * rad);
+        T const w = h * height / width; ///todo max(width , Height) / min(width , Height)?
+
+        tmat4x4<T> Result(static_cast<T>(0));
+        Result[0][0] = w;
+        Result[1][1] = h;
+        Result[2][3] = static_cast<T>(1);
 
 #if (LC_DEPTH_CLIP_SPACE == LC_DEPTH_ZERO_TO_ONE)
-		Result[2][2] = zFar / (zFar - zNear);
-		Result[3][2] = -(zFar * zNear) / (zFar - zNear);
+        Result[2][2] = zFar / (zFar - zNear);
+        Result[3][2] = -(zFar * zNear) / (zFar - zNear);
 #else
-		Result[2][2] = (zFar + zNear) / (zFar - zNear);
-		Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
+        Result[2][2] = (zFar + zNear) / (zFar - zNear);
+        Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
 #endif
 
-		return Result;
+        return Result;
     }
 
     template <typename T> tmat4x4<T> perspectiveFovRH(T fov, T width, T height, T zNear, T zFar) {
-		assert(width > static_cast<T>(0));
-		assert(height > static_cast<T>(0));
-		assert(fov > static_cast<T>(0));
-	
-		T const rad = fov;
-        T const h = std::cos(static_cast<T>(0.5) * rad) / std::sin(static_cast<T>(0.5) * rad);
-		T const w = h * height / width; ///todo max(width , Height) / min(width , Height)?
+        assert(width > static_cast<T>(0));
+        assert(height > static_cast<T>(0));
+        assert(fov > static_cast<T>(0));
 
-		tmat4x4<T> Result(static_cast<T>(0));
-		Result[0][0] = w;
-		Result[1][1] = h;
-		Result[2][3] = - static_cast<T>(1);
+        T const rad = fov;
+        T const h = std::cos(static_cast<T>(0.5) * rad) / std::sin(static_cast<T>(0.5) * rad);
+        T const w = h * height / width; ///todo max(width , Height) / min(width , Height)?
+
+        tmat4x4<T> Result(static_cast<T>(0));
+        Result[0][0] = w;
+        Result[1][1] = h;
+        Result[2][3] = - static_cast<T>(1);
 
 #if (LC_DEPTH_CLIP_SPACE == LC_DEPTH_ZERO_TO_ONE)
-		Result[2][2] = zFar / (zNear - zFar);
-		Result[3][2] = -(zFar * zNear) / (zFar - zNear);
+        Result[2][2] = zFar / (zNear - zFar);
+        Result[3][2] = -(zFar * zNear) / (zFar - zNear);
 #else
-		Result[2][2] = - (zFar + zNear) / (zFar - zNear);
-		Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
+        Result[2][2] = - (zFar + zNear) / (zFar - zNear);
+        Result[3][2] = - (static_cast<T>(2) * zFar * zNear) / (zFar - zNear);
 #endif
 
-		return Result;
+        return Result;
     }
 
     // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
The full diff contains whitespace edits. See the first commit (d714d76) for functional changes:

- Fix MINIMATH_NAMESPACE typo
- Add missing `<cstddef>` and `<limits>` includes
- Add std:: prefix to size_t types (not defined by default on some platforms)
- Make some functions like _transpose() and _inverse() const
- Add `v*v`, `v/v`, `v+v`, `v-v`, `m*m` operators
- Fix typos in `m*s`, `s*m` operators
- Fix transpose typos
- Fix mat4x4 translate and rotate functions
- Replace glm:: namespaced trig functions with std::
  